### PR TITLE
Soft-delete for Categories

### DIFF
--- a/src/components/pages/categories/components/CategoriesTable.vue
+++ b/src/components/pages/categories/components/CategoriesTable.vue
@@ -116,7 +116,7 @@ export default {
       this.categoriesTable.clear();
     },
     reload: function () {
-      categoriesService.getCategories().then((categories) => {
+      categoriesService.getActiveCategories().then((categories) => {
         this.render(categories);
       });
     },
@@ -188,7 +188,7 @@ export default {
     },
   },
   mounted() {
-    categoriesService.getCategories().then((categories) => {
+    categoriesService.getActiveCategories().then((categories) => {
       this.init(categories);
     });
   },

--- a/src/components/pages/dashboard/components/CategoryBalanceSection.vue
+++ b/src/components/pages/dashboard/components/CategoryBalanceSection.vue
@@ -32,7 +32,8 @@ export default {
           .then((financialReport) => {
             var categoryWithBalance = category;
             categoryWithBalance.balance = financialReport.totalValue;
-            self.categories.push(categoryWithBalance);
+            if(category.deleted == false || categoryWithBalance.balance != 0)
+              self.categories.push(categoryWithBalance);
           });
       });
     });

--- a/src/components/pages/transactions/TransactionsPage.vue
+++ b/src/components/pages/transactions/TransactionsPage.vue
@@ -1,13 +1,12 @@
 <template>
-  <div v-if="categoriesFetched && accountsFetched">
-    <TransactionsTable ref="transactionsTable" v-bind:categories="categories" v-bind:accounts="accounts"/>
-    <AddTransaction v-on:transaction-added="refreshTransactionsTable" v-bind:categories="categories" v-bind:accounts="accounts"/>
+  <div v-if="accountsFetched">
+    <TransactionsTable ref="transactionsTable" v-bind:accounts="accounts"/>
+    <AddTransaction v-on:transaction-added="refreshTransactionsTable" v-bind:accounts="accounts"/>
   </div>
 </template>
 
 <script>
 import TransactionsTable from "./components/TransactionsTable.vue";
-import { categoriesService } from "../../../services/categoriesService.js";
 import { accountsService } from "../../../services/accountsService.js";
 import AddTransaction from "./components/AddTransaction.vue";
 
@@ -19,8 +18,6 @@ export default {
   },
   data: function () {
     return {
-      categories: [],
-      categoriesFetched: false,
       accounts: [],
       accountsFetched: false
     }
@@ -31,16 +28,6 @@ export default {
     },
   },
   mounted() {
-
-    categoriesService
-      .getCategories()
-      .then((categories) => {
-        this.categories = categories;
-        this.categoriesFetched = true;
-      });
-
-      
-
     accountsService.getAccounts().then((accounts) => {
       this.accounts = accounts;
       this.accountsFetched = true;

--- a/src/components/pages/transactions/components/AddTransaction.vue
+++ b/src/components/pages/transactions/components/AddTransaction.vue
@@ -145,7 +145,7 @@
 <script>
 import { transactionsService } from "../../../../services/transactionsService.js";
 import { periodsService } from "../../../../services/periodsService.js";
-import { categoriesService } from "../../../services/categoriesService.js";
+import { categoriesService } from "../../../../services/categoriesService.js";
 
 export default {
   name: "AddTransaction",

--- a/src/components/pages/transactions/components/AddTransaction.vue
+++ b/src/components/pages/transactions/components/AddTransaction.vue
@@ -145,10 +145,11 @@
 <script>
 import { transactionsService } from "../../../../services/transactionsService.js";
 import { periodsService } from "../../../../services/periodsService.js";
+import { categoriesService } from "../../../services/categoriesService.js";
 
 export default {
   name: "AddTransaction",
-  props: ["categories", "accounts"],
+  props: ["accounts"],
   data: function () {
     return {
       transaction: {
@@ -163,6 +164,7 @@ export default {
       attemptedToSubmit: false,
       splitIntoCategories: false,
       periods: [],
+      categories: []
     };
   },
   methods: {
@@ -301,6 +303,12 @@ export default {
     periodsService.getPeriods().then((periods) => {
       self.periods = periods;
     });
+    categoriesService
+      .getActiveCategories()
+      .then((categories) => {
+        this.categories = categories;
+      });
+
   },
 };
 </script>

--- a/src/components/pages/transactions/components/TransactionsTable.vue
+++ b/src/components/pages/transactions/components/TransactionsTable.vue
@@ -86,7 +86,7 @@ import {
   getDateRangeByMonthRange,
   convertDateToDotNetString,
 } from "../../../../common/utils.js";
-import { categoriesService } from "../../../services/categoriesService.js";
+import { categoriesService } from "../../../../services/categoriesService.js";
 
 var possibleFilters = [
   {

--- a/src/components/pages/transactions/components/TransactionsTable.vue
+++ b/src/components/pages/transactions/components/TransactionsTable.vue
@@ -86,6 +86,7 @@ import {
   getDateRangeByMonthRange,
   convertDateToDotNetString,
 } from "../../../../common/utils.js";
+import { categoriesService } from "../../../services/categoriesService.js";
 
 var possibleFilters = [
   {
@@ -116,14 +117,15 @@ var possibleFilters = [
 
 export default {
   name: "TransactionsTable",
-  props: ["categories", "accounts"],
+  props: ["accounts"],
   data: function () {
     return {
       latestPeriod: null,
       filters: possibleFilters,
       currentFilter: possibleFilters[0],
       removeButtonEnabled: false,
-      transactionsTable: null
+      transactionsTable: null,
+      categories: []
     };
   },
   methods: {
@@ -312,6 +314,13 @@ export default {
       .then((financialReport) => {
         this.init(financialReport.financialTransactions);
       });
+
+      categoriesService
+      .getCategories()
+      .then((categories) => {
+        this.categories = categories;
+      });
+
   },
 };
 </script>

--- a/src/services/categoriesService.js
+++ b/src/services/categoriesService.js
@@ -30,12 +30,20 @@ let updateCategory = function(category){
     });
 }
 
+let getActiveCategories = function(){
+    return new Promise((resolve) => {
+        let getCategoriesUrl = `${baseUrl}/Categories?deleted=false`;
+        axios.get(getCategoriesUrl).then(response => resolve(response.data));
+    });
+}
+
 
 let categoriesService = {
     getCategories,
     deleteCategoryById,
     addCategory,
-    updateCategory
+    updateCategory,
+    getActiveCategories
 };
 
 


### PR DESCRIPTION
Added feature that allows categories to be "soft-deleted". Soft-deleted categories do not show as an option for new transactions, nor are they visible in the categories table. However, they maintain their relationships to old transactions, and are visible in the dashboard if they have either assigned budget, or pending debt.

Completes task [AB#341](https://dev.azure.com/juankmilohst/f4496097-76d7-4e7b-94de-f89cb3353df1/_workitems/edit/341) and resolves user story [AB#319](https://dev.azure.com/juankmilohst/f4496097-76d7-4e7b-94de-f89cb3353df1/_workitems/edit/319)